### PR TITLE
Update ProductRecommendationsViewModel getProductId

### DIFF
--- a/ViewModel/ProductRecommendationsViewModel.php
+++ b/ViewModel/ProductRecommendationsViewModel.php
@@ -35,15 +35,13 @@ class ProductRecommendationsViewModel implements ArgumentInterface
         $this->registry = $registry;
     }
 
-    public function getProductId(): ?int
+    public function getProductId(): int
     {
-        /** @var Product|null $product */
-        $product = $this->registry->registry('current_product') ?: null;
+        return $this->getProduct()->getId();
+    }
 
-        if (!$product) {
-            return null;
-        }
-
-        return (int) $product->getId();
+    private function getProduct(): Product
+    {
+        return $this->registry->registry('current_product');
     }
 }


### PR DESCRIPTION
I wrote this update because, imho, Product can not be null.

And it is not necessary to int-cast the value of getId